### PR TITLE
Add safety checks for unknown functions in PermMem

### DIFF
--- a/Anim8.d
+++ b/Anim8.d
@@ -39,6 +39,14 @@ func void A8Head_UnArchiver(var A8Head this) {
     if(PM_Exists("dif"))   { this.dif  = PM_LoadInt("dif");      };
     if(PM_Exists("ddif"))  { this.ddif = PM_LoadInt("ddif");     };
     this.queue = PM_Load("queue");
+
+    // Fix function signature of invalid functions
+    if (this.dfnc == MEM_GetFuncPtr(_PM_EmptyFunc_int)) {
+        this.dfnc = MEM_GetFuncPtr(_PM_EmptyFunc_void);
+    };
+    if (this.fnc == MEM_GetFuncPtr(_PM_EmptyFunc_int)) && (this.data) {
+        this.fnc = MEM_GetFuncPtr(_PM_EmptyFunc_int_int);
+    };
 };
 
 

--- a/FrameFunctions.d
+++ b/FrameFunctions.d
@@ -45,6 +45,11 @@ func void FFItem_Unarchiver(var FFItem this) {
 	if (PM_Exists("gametime")) {
 		this.gametime = PM_Load("gametime");
 	};
+
+    // Fix function signature of invalid functions
+    if (this.fncID == MEM_GetFuncPtr(_PM_EmptyFunc_int)) && (!this.hasData) {
+        this.fncID = MEM_GetFuncPtr(_PM_EmptyFunc_void);
+    };
 };
 
 var int _FF_Symbol;

--- a/PermMem.d
+++ b/PermMem.d
@@ -1677,8 +1677,16 @@ func string PM_LoadString(var string name) {
     return os.content;
 };
 
+func void _PM_EmptyFunc_void() {};
+func void _PM_EmptyFunc_int(var int i) {};
+func void _PM_EmptyFunc_int_int(var int i, var int j) {};
+
 func int PM_LoadFuncID(var string name) {
-    return MEM_FindParserSymbol(PM_LoadString(name));
+    var int funcID; funcID = MEM_FindParserSymbol(PM_LoadString(name));
+    if (funcID == -1) {
+        funcID = MEM_GetFuncID(_PM_EmptyFunc_void);
+    };
+    return funcID;
 };
 
 func int PM_LoadFuncOffset(var string name) {

--- a/PermMem.d
+++ b/PermMem.d
@@ -1684,7 +1684,7 @@ func void _PM_EmptyFunc_int_int(var int i, var int j) {};
 func int PM_LoadFuncID(var string name) {
     var int funcID; funcID = MEM_FindParserSymbol(PM_LoadString(name));
     if (funcID == -1) {
-        funcID = MEM_GetFuncID(_PM_EmptyFunc_void);
+        funcID = MEM_GetFuncID(_PM_EmptyFunc_int); // Most common function signature in LeGo classes
     };
     return funcID;
 };

--- a/Queue.d
+++ b/Queue.d
@@ -138,6 +138,11 @@ func void callbackData_Unarchiver(var callbackData this) {
 	};
 	this.userData = PM_Load("userData");
 	this.hasData = PM_Load("hasData");
+
+	// Fix function signature of invalid functions
+	if (this.funcID == MEM_GetFuncID(_PM_EmptyFunc_int)) && (!this.hasData) {
+		this.funcID = MEM_GetFuncID(_PM_EmptyFunc_void);
+	};
 };
 
 func int _CQ_CBData(var int ID, var int uData, var int hData) {


### PR DESCRIPTION
I created a separate branch and PR for #21, because it requires some design decision.

Here, the default empty function to use, if a function is invalid, has the signature `void fnc(int)`, as it is the most common one among the LeGo PermMem classes (see second table below).

I chose this signature instead of `void fnc()`, because this reduces the amount times this empty function has to be exchanged to match the respective class function signature.

This way, only four replacements in the respective unarchiver functions are necessary
&nbsp; | Different signature
------- | -----
A8Head.fnc            | void fnc(int) or void fnc(int, int)
A8Head.dfnc           | void fnc()
callbackData.funcID         | void fnc() or void fnc(int)
FFItem.fncID          | void fnc() or void fnc(int)

instead of replacing the empty function also for
&nbsp; | Same signature
------- | -----
lCBuff.OnApply        | void fnc(int)
lCBuff.OnTick         | void fnc(int)
lCBuff.OnRemoved      | void fnc(int)
_Button.on_enter       | void fnc(int)
_Button.on_leave       | void fnc(int)
_Button.on_click       | void fnc(int)
lCEvent      | void fnc(int)


This struck me as the most convenient way to do it. My only worry is the choice of the default function signature, see 287afa0. @Lehona Do you think this is the best way to do it? Feel free to merge if you see no issues.